### PR TITLE
Verify conversation can continue after agent error

### DIFF
--- a/bubbletea/model_test.go
+++ b/bubbletea/model_test.go
@@ -215,7 +215,7 @@ func TestModel_Update(t *testing.T) {
 		require.Error(t, m.Err())
 
 		// Type and submit.
-		m.Input.SetValue("retry")
+		m.Input = typeInputString(t, m.Input, "retry")
 		m = updateModel(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 
 		assert.True(t, m.Running())
@@ -809,6 +809,9 @@ func TestModel_Teatest(t *testing.T) {
 		t.Parallel()
 
 		var callCount atomic.Int32
+		// The agent mutates session.Messages directly — this mirrors the real
+		// contract where both model (user messages) and agent (assistant messages)
+		// append to the shared session.
 		agent := func(_ context.Context, session *pipe.Session, onEvent func(pipe.Event)) error {
 			n := callCount.Add(1)
 			if n == 1 {


### PR DESCRIPTION
## Summary
- Added 3 unit tests verifying error recovery: input accepts text after error, submit clears error and starts new run, Ctrl+C quits after error
- Added 1 integration test (teatest) exercising the full error → retry → success cycle
- All tests confirm the existing error recovery code works correctly — no production changes needed

Closes #45

## Test Plan
- [x] `make validate` passes
- [x] roborev review passed (job 421, no issues)

Generated with [Claude Code](https://claude.com/claude-code)