### PR TITLE
Mouse text selection via Alt+M toggle

### DIFF
--- a/bubbletea/model.go
+++ b/bubbletea/model.go
@@ -317,7 +317,15 @@ func (m Model) submitInput(text string) (tea.Model, tea.Cmd) {
 
 	m.Input.Blur()
 
+	// Re-enable mouse capture so scrolling works during the run.
+	var mouseCmd tea.Cmd
+	if !m.mouseEnabled {
+		m.mouseEnabled = true
+		mouseCmd = tea.EnableMouseCellMotion
+	}
+
 	return m, tea.Batch(
+		mouseCmd,
 		startAgent(m.run, ctx, m.session, m.eventCh, m.doneCh),
 		listenForEvent(m.eventCh, m.doneCh),
 	)

--- a/bubbletea/model_test.go
+++ b/bubbletea/model_test.go
@@ -581,6 +581,18 @@ func TestModel_MouseToggle(t *testing.T) {
 		m = updateModel(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}, Alt: true})
 		assert.Contains(t, m.View(), "Alt+M")
 	})
+
+	t.Run("submit re-enables mouse when disabled", func(t *testing.T) {
+		t.Parallel()
+		m := initModel(t, nopAgent)
+		// Disable mouse.
+		m = updateModel(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}, Alt: true})
+		assert.False(t, m.MouseEnabled())
+		// Type and submit.
+		m.Input.SetValue("hello")
+		m = updateModel(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+		assert.True(t, m.MouseEnabled())
+	})
 }
 
 func TestModel_InputHeightResetOnSubmit(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add Alt+M keybinding to toggle mouse capture on/off, enabling native terminal text selection
- Status line shows "Mouse off (Alt+M to re-enable)" hint when mouse capture is disabled
- Mouse scrolling remains the default; toggle is ignored during agent runs

Closes #46

## Test Plan
- [x] `make validate` passes
- [x] roborev review passed

Generated with [Claude Code](https://claude.com/claude-code)