### PR TITLE
Preserve Gemini function-call thought_signature for lossless replay

### DIFF
--- a/docs/plans/2026-02-21-gemini-toolcall-signature-design.md
+++ b/docs/plans/2026-02-21-gemini-toolcall-signature-design.md
@@ -1,0 +1,47 @@
+# Preserve Gemini function-call thought_signature
+
+Issue: #52
+
+## Problem
+
+Gemini can attach `thought_signature` to `FunctionCall` parts without a
+preceding `ThinkingBlock`. Current code only backfills signatures to thinking
+blocks, so when no thinking block exists, the signature is dropped. On replay,
+Gemini rejects with `INVALID_ARGUMENT`.
+
+## Design
+
+Four changes:
+
+### 1. Domain model (`message.go`)
+
+Add `Signature []byte` to `ToolCallBlock`. Opaque provider metadata, same
+pattern as `ThinkingBlock.Signature`.
+
+### 2. Stream ingestion (`gemini/stream.go`)
+
+In `processPart` for `FunctionCall`, always store `part.ThoughtSignature` on
+`ToolCallBlock.Signature`. Keep existing `backfillThinkingSignature` so
+thinking blocks also get their signatures for egress.
+
+### 3. Egress conversion (`gemini/client.go`)
+
+In `convertParts`, use `ToolCallBlock.Signature` directly on `FunctionCall`
+parts. Remove the `lastSig` heuristic that inferred signatures from preceding
+thinking blocks. Each content block is now self-contained — no cross-block
+inference.
+
+### 4. JSON persistence (`json/content_block.go`)
+
+Add `signature` field to `tool_call` blocks with base64 encoding (same pattern
+as thinking blocks). Old sessions without this field load with nil signature.
+
+## Test changes
+
+- `TestStream_FunctionCallThoughtSignatureNoPrecedingThinkingBlock`: Verify
+  signature IS preserved on `ToolCallBlock`.
+- `TestStream_FunctionCallThoughtSignatureBackfillsThinking`: Still works, AND
+  preserves signature on `ToolCallBlock`.
+- New: egress uses call-level signature directly, no inference from thinking.
+- New: JSON round-trip for tool call with signature.
+- All existing tests remain green.

--- a/gemini/stream.go
+++ b/gemini/stream.go
@@ -238,6 +238,7 @@ func (s *stream) processPart(part *genai.Part) error {
 			ID:        id,
 			Name:      part.FunctionCall.Name,
 			Arguments: json.RawMessage(rawArgs),
+			Signature: slices.Clone(part.ThoughtSignature),
 		}
 		s.msg.Content = append(s.msg.Content, call)
 		s.blocks = append(s.blocks, &blockState{blockType: "tool_call"})

--- a/gemini/stream_test.go
+++ b/gemini/stream_test.go
@@ -268,6 +268,7 @@ func TestStream_FunctionCallThoughtSignatureBackfillsThinking(t *testing.T) {
 		ID:        "tc_1",
 		Name:      "read",
 		Arguments: json.RawMessage(`{"path":"a.go"}`),
+		Signature: []byte("sig-from-call"),
 	}, msg.Content[1])
 	assert.Equal(t, pipe.StopToolUse, msg.StopReason)
 }
@@ -310,6 +311,7 @@ func TestStream_FunctionCallThoughtSignatureNoPrecedingThinkingBlock(t *testing.
 		ID:        "tc_1",
 		Name:      "read",
 		Arguments: json.RawMessage(`{"path":"a.go"}`),
+		Signature: []byte("sig-orphan"),
 	}, msg.Content[0])
 }
 

--- a/message.go
+++ b/message.go
@@ -87,6 +87,7 @@ type ToolCallBlock struct {
 	ID        string
 	Name      string
 	Arguments json.RawMessage
+	Signature []byte
 }
 
 func (ToolCallBlock) contentBlock() {}


### PR DESCRIPTION
## Summary
- Added `Signature []byte` to `ToolCallBlock` for direct storage of Gemini's `thought_signature`
- Capture signature at stream ingestion, persist through JSON (base64), send on egress
- Removed `lastSig` heuristic — each content block is now self-contained

Closes #52

## Test Plan
- [x] `make validate` passes (vet, lint, race tests)
- [x] roborev review passed

Generated with [Claude Code](https://claude.com/claude-code)